### PR TITLE
Fix ImportError for mock module on Python3.

### DIFF
--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -4,7 +4,10 @@ from __future__ import unicode_literals
 
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError:
+    from unittest import mock
 
 from inthing import Result, Stream, Event
 


### PR DESCRIPTION
With python3.3 mock became a sub-module inside the unittest package.
