### PR TITLE
Use builtin json support from requests.

### DIFF
--- a/inthing/stream.py
+++ b/inthing/stream.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import json
 import logging
 import mimetypes
 import os
@@ -244,7 +243,7 @@ class Stream(object):
                 raise errors.ConnectivityError("unable to contact server")
 
             try:
-                result = json.loads(response.content)
+                result = response.json()
             except Exception as e:
                 raise errors.BadResponse('unable to decode response from server ({})'.format(e))
 


### PR DESCRIPTION
Under python3, json.loads expects a 'str', but response.content is 'bytes'.
But requests has a builtin support for json responses:
http://docs.python-requests.org/en/master/user/quickstart/#json-response-content
